### PR TITLE
Fix support for weather providers without "Location" property (fixes NOAA weather add-on)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ __Additional Information__
 - Combine song artist and title  (Song artist - song title)
 - Show only music information (If this is enabled and a song is playing, only song info will be shown)
 - Enable album art
-- Enable weather information
+- Enable weather temperature information
+- Enable weather conditions information
 - Weather icons
 - Enable CPU usage information
 - Enable battery level information

--- a/default.py
+++ b/default.py
@@ -101,6 +101,7 @@ class Screensaver(xbmcgui.WindowXMLDialog):
         self.tvshows = Addon.getSetting('tvshows')
         self.music = Addon.getSetting('music')
         self.weatherinfoshow = Addon.getSetting('weatherinfoshow')
+        self.weathercondshow = Addon.getSetting('weathercondshow')
         self.albumartshow = Addon.getSetting('albumartshow')
         self.weathericonf = Addon.getSetting('weathericonformat')
         self.infoswitch = int(Addon.getSetting('infoswitch'))
@@ -231,8 +232,16 @@ class Screensaver(xbmcgui.WindowXMLDialog):
                     self.informationlist.append('$INFO[VideoPlayer.TVShowTitle]')
                 if xbmc.getInfoLabel('VideoPlayer.Title'):
                     self.informationlist.append('$INFO[VideoPlayer.Title]')
-            if self.weatherinfoshow == 'true' and xbmc.getInfoLabel('Weather.Location'):
-                self.informationlist.append("$INFO[Weather.Temperature] - $INFO[Weather.Conditions]")
+            if self.weatherinfoshow == 'true':
+                if xbmc.getInfoLabel('Weather.Temperature'):
+                    self.informationlist.append("$INFO[Weather.Temperature]")
+                else:
+                    self.informationlist.append("Weather.Temperature: resource is not provided by your weather add-on")
+            if self.weathercondshow == 'true':
+                if xbmc.getInfoLabel('Weather.Conditions'):
+                    self.informationlist.append("$INFO[Weather.Conditions]")
+                else:
+                    self.informationlist.append("Weather.Conditions: resource is not provided by your weather add-on")
             if self.cpuusage == 'true' and xbmc.getInfoLabel('System.CpuUsage'):
                 self.corenumber = xbmc.getInfoLabel('System.CpuUsage').count('%')
                 if self.corenumber == 1:
@@ -285,14 +294,14 @@ class Screensaver(xbmcgui.WindowXMLDialog):
             if self.informationshow == 'true':
                 if len(self.informationlist) != 0:
                     self.information_control.setPosition(0, 85)
-                    if ((self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Location')) or (self.nowplayinginfoshow == 'true' and self.albumartshow =='true' and xbmc.getInfoLabel('MusicPlayer.Artist'))):
+                    if ((self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Conditions')) or (self.nowplayinginfoshow == 'true' and self.albumartshow =='true' and xbmc.getInfoLabel('MusicPlayer.Artist'))):
                         self.icon_control.setPosition(115, 120)
                         self.container.setHeight(int(240 + 30 * (self.zoom / 100 - 1)))
                     else:
                         self.container.setHeight(int(150 + 50 * (self.zoom / 100 - 1)))
                         self.icon_control.setVisible(False)
                 else:
-                    if ((self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Location')) or (self.nowplayinginfoshow == 'true' and self.albumartshow =='true' and xbmc.getInfoLabel('MusicPlayer.Artist'))):
+                    if ((self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Conditions')) or (self.nowplayinginfoshow == 'true' and self.albumartshow =='true' and xbmc.getInfoLabel('MusicPlayer.Artist'))):
                         self.icon_control.setPosition(115, 90)
                         self.container.setHeight(int(210 + 50 * (self.zoom / 100 - 1)))
                     else:
@@ -306,11 +315,11 @@ class Screensaver(xbmcgui.WindowXMLDialog):
         else:
             if self.informationshow == 'true':
                 if len(self.informationlist) != 0:
-                    if not((self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Location')) or (self.nowplayinginfoshow == 'true' and self.albumartshow =='true' and xbmc.getInfoLabel('MusicPlayer.Artist'))):
+                    if not((self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Conditions')) or (self.nowplayinginfoshow == 'true' and self.albumartshow =='true' and xbmc.getInfoLabel('MusicPlayer.Artist'))):
                         self.container.setHeight(int(180 + 50 * (self.zoom / 100 - 1)))
                         self.icon_control.setVisible(False)
                 else:
-                    if ((self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Location')) or (self.nowplayinginfoshow == 'true' and self.albumartshow =='true' and xbmc.getInfoLabel('MusicPlayer.Artist'))):
+                    if ((self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Conditions')) or (self.nowplayinginfoshow == 'true' and self.albumartshow =='true' and xbmc.getInfoLabel('MusicPlayer.Artist'))):
                         self.icon_control.setPosition(115, 120)
                         self.container.setHeight(int(240 + 30 * (self.zoom / 100 - 1)))
                     else:
@@ -334,7 +343,7 @@ class Screensaver(xbmcgui.WindowXMLDialog):
 		#setting the icon image
         if self.nowplayinginfoshow == 'true' and self.albumartshow == 'true' and (xbmc.getInfoLabel('MusicPlayer.Artist') or xbmc.getInfoLabel('MusicPlayer.Title')):
             self.icon = xbmc.getInfoLabel('Player.art(thumb)')
-        elif self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Location'):
+        elif self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Conditions'):
             self.icon = os.path.join(path,"resources/weathericons/",self.weathericonset[int(self.weathericonf)],xbmc.getInfoLabel('Window(Weather).Property(Current.FanartCode)')) + ".png"
         else:
             self.icon_control.setImage(os.path.join(path,"resources/weathericons/",self.weathericonset[int(self.weathericonf)],xbmc.getInfoLabel('Window(Weather).Property(Current.FanartCode)')) + ".png")
@@ -531,7 +540,7 @@ class Screensaver(xbmcgui.WindowXMLDialog):
             self.date_control.setLabel(self.date)
         if len(self.informationlist) != 0:
             self.information_control.setLabel(self.information)
-        if (self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Location')) or (self.nowplayinginfoshow == 'true' and self.albumartshow == 'true' and (xbmc.getInfoLabel('MusicPlayer.Artist') or xbmc.getInfoLabel('MusicPlayer.Title'))):
+        if (self.weatherinfoshow == 'true' and self.weathericonf != '0' and xbmc.getInfoLabel('Weather.Conditions')) or (self.nowplayinginfoshow == 'true' and self.albumartshow == 'true' and (xbmc.getInfoLabel('MusicPlayer.Artist') or xbmc.getInfoLabel('MusicPlayer.Title'))):
             self.icon_control.setImage(self.icon)
         self.hour_colorcontrol.setLabel(self.hourcolor)
         self.colon_colorcontrol.setLabel(self.coloncolor)

--- a/resources/language/resource.language.af_za/strings.po
+++ b/resources/language/resource.language.af_za/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.am_et/strings.po
+++ b/resources/language/resource.language.am_et/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.az_az/strings.po
+++ b/resources/language/resource.language.az_az/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.be_by/strings.po
+++ b/resources/language/resource.language.be_by/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.bs_ba/strings.po
+++ b/resources/language/resource.language.bs_ba/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.ca_es/strings.po
+++ b/resources/language/resource.language.ca_es/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.cy_gb/strings.po
+++ b/resources/language/resource.language.cy_gb/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.da_dk/strings.po
+++ b/resources/language/resource.language.da_dk/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -232,10 +232,15 @@ msgstr "Songinterpret und Titel zusammenführen"
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Wetterinformation aktivieren"
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr "Wettersymbole"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.en_au/strings.po
+++ b/resources/language/resource.language.en_au/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -249,10 +249,16 @@ msgstr ""
 #empty strings from id 32224 to 32229
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-#empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+#empty strings from id 32236 to 32239
 
 msgctxt "#32240"
 msgid "Weather icons"

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -219,8 +219,8 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
-msgstr "Enable weather information"
+msgid "Enable weather temperature information"
+msgstr "Enable weather temperature information"
 
 msgctxt "#32240"
 msgid "Weather icons"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.eo/strings.po
+++ b/resources/language/resource.language.eo/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.es_ar/strings.po
+++ b/resources/language/resource.language.es_ar/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -7,15 +7,15 @@ msgstr ""
 "Project-Id-Version: KODI Addons\n"
 "Report-Msgid-Bugs-To: translations@kodi.tv\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2024-05-31 15:16+0000\n"
-"Last-Translator: roliverosc <roliverosc@hotmail.com>\n"
+"PO-Revision-Date: 2024-01-12 00:13+0000\n"
+"Last-Translator: José Antonio Alvarado <jalvarado0.eses@gmail.com>\n"
 "Language-Team: Spanish (Spain) <https://kodi.weblate.cloud/projects/kodi-add-ons-look-and-feel/screensaver-digitalclock/es_es/>\n"
 "Language: es_es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.5.4\n"
+"X-Generator: Weblate 5.3\n"
 
 msgctxt "Addon Summary"
 msgid "Digital clock screensaver"
@@ -82,7 +82,7 @@ msgstr "Velocidad de movimiento"
 
 msgctxt "#32111"
 msgid "Slow"
-msgstr "Lento"
+msgstr "Despacio"
 
 msgctxt "#32112"
 msgid "Normal"
@@ -220,7 +220,7 @@ msgid "Merge song artist and title"
 msgstr "Combinar artista y título de canción"
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Activar información meteorológica"
 
 msgctxt "#32240"
@@ -229,7 +229,7 @@ msgstr "Iconos meteorológicos"
 
 msgctxt "#32241"
 msgid "Hide weather icon"
-msgstr "Ocultar el icono de meteorología"
+msgstr "Ocultar el icono del tiempo"
 
 msgctxt "#32242"
 msgid "Icon set 1"
@@ -249,56 +249,56 @@ msgstr "Conjunto de iconos 4"
 
 msgctxt "#32250"
 msgid "Enable album art"
-msgstr "Activar carátula de álbum"
+msgstr "Habilitar carátula de álbum"
 
 # empty strings from id 32251 to 32259
 msgctxt "#32260"
 msgid "Enable CPU usage information"
-msgstr "Activar información de uso de la CPU"
+msgstr "Habilitar información del uso de la CPU"
 
 msgctxt "#32261"
 msgid "Enable battery level information"
-msgstr "Activar información de nivel de batería"
+msgstr "Habilitar información del nivel de batería"
 
 msgctxt "#32262"
 msgid "Enable free memory information"
-msgstr "Activar información de memoria libre"
+msgstr "Habilitar información de memoria libre"
 
 msgctxt "#32263"
 msgid "Enable movie library information"
-msgstr "Activar información de la biblioteca de películas"
+msgstr "Habilitar información de la biblioteca de películas"
 
 msgctxt "#32264"
 msgid "Enable TV show library information"
-msgstr "Activar información de la biblioteca de series de TV"
+msgstr "Habilitar información de la biblioteca de programas de TV"
 
 msgctxt "#32265"
 msgid "Enable music library information"
-msgstr "Activar información de la biblioteca de música"
+msgstr "Habilitar información de la biblioteca de música"
 
 msgctxt "#32266"
 msgid "Enable CPU temperature"
-msgstr "Activar temperatura de la CPU"
+msgstr "Habilitar temperatura de la CPU"
 
 msgctxt "#32267"
 msgid "Enable GPU temperature"
-msgstr "Activar temperatura de la GPU"
+msgstr "Habilitar temperatura de la GPU"
 
 msgctxt "#32268"
 msgid "Enable HDD temperature"
-msgstr "Activar temperatura del disco duro"
+msgstr "Habilitar temperatura del disco duro"
 
 msgctxt "#32269"
 msgid "Enable FPS"
-msgstr "Activar FPS"
+msgstr "Habilitar FPS"
 
 msgctxt "#32270"
 msgid "Enable current uptime"
-msgstr "Activar tiempo de actividad actual"
+msgstr "Habilitar tiempo de actividad actual"
 
 msgctxt "#32271"
 msgid "Enable total uptime"
-msgstr "Activar tiempo de actividad total"
+msgstr "Habilitar tiempo de actividad total"
 
 # empty strings from id 32272 to 32279
 msgctxt "#32280"
@@ -323,11 +323,11 @@ msgstr "Películas vistas:"
 
 msgctxt "#32285"
 msgid "Unwatched movies:"
-msgstr "Películas no vistas:"
+msgstr "Películas sin ver:"
 
 msgctxt "#32286"
 msgid "Total TV shows:"
-msgstr "Total series de TV:"
+msgstr "Total programas de TV:"
 
 msgctxt "#32287"
 msgid "Total episodes:"
@@ -335,7 +335,7 @@ msgstr "Total episodios:"
 
 msgctxt "#32288"
 msgid "Watched TV shows:"
-msgstr "Series vistas:"
+msgstr "Programas de TV vistos:"
 
 msgctxt "#32289"
 msgid "Watched episodes:"
@@ -343,11 +343,11 @@ msgstr "Episodios vistos:"
 
 msgctxt "#32290"
 msgid "Unwatched TV shows:"
-msgstr "Series no vistas:"
+msgstr "Programas de TV sin ver:"
 
 msgctxt "#32291"
 msgid "Unwatched episodes:"
-msgstr "Episodios no vistos:"
+msgstr "Episodios sin ver:"
 
 msgctxt "#32292"
 msgid "Artists:"
@@ -392,11 +392,11 @@ msgstr "Elegir el color de la hora y la opacidad  - [COLOR $INFO[Skin.String(scr
 
 msgctxt "#32311"
 msgid "Random hour color"
-msgstr "Color aleatorio de hora"
+msgstr "Color de la hora aleatorio"
 
 msgctxt "#32312"
 msgid "Random hour opacity"
-msgstr "Opacidad aleatoria de hora"
+msgstr "Opacidad de la hora aleatoria"
 
 # empty strings from id 32313 to 32319
 msgctxt "#32320"
@@ -484,7 +484,7 @@ msgstr "Elegir el color de la sombra del texto y la opacidad - [COLOR $INFO[Skin
 # empty strings from id 32501 to 32504
 msgctxt "#32505"
 msgid "Choose background image aspect ratio:"
-msgstr "Elegir relación de aspecto de la imagen de fondo:"
+msgstr "Elegir la relación de aspecto de la imagen de fondo:"
 
 msgctxt "#32506"
 msgid "Fill the screen"
@@ -512,7 +512,7 @@ msgstr "Presentación de imágenes"
 
 msgctxt "#32514"
 msgid "Skin Helper Backgrounds"
-msgstr "Fondos Skin Helper"
+msgstr "Fondos para el tema del servicio de ayuda"
 
 msgctxt "#32515"
 msgid "Dim"
@@ -537,7 +537,7 @@ msgstr "¡Atención! ¡Tener una imagen fija en la pantalla puede quemarla!"
 
 msgctxt "#32540"
 msgid "Choose slideshow directory"
-msgstr "Elegir directorio de la presentación de imágenes"
+msgstr "Elegir el directorio de la presentación de imágenes"
 
 msgctxt "#32550"
 msgid "Random images"
@@ -602,7 +602,7 @@ msgstr "¡Requiere skin.helper.backgrounds!"
 
 msgctxt "#32580"
 msgid "Choose Skin Helper background"
-msgstr "Elegir fondo de Skin Helper"
+msgstr "Eligir el fondo del tema del servicio de ayuda"
 
 msgctxt "#32581"
 msgid "Movie random fanart"
@@ -610,7 +610,7 @@ msgstr "Fanart aleatorio de películas"
 
 msgctxt "#32582"
 msgid "TV show random fanart"
-msgstr "Fanart aleatorio de series de TV"
+msgstr "Fanart aleatorio de programas de TV"
 
 msgctxt "#32583"
 msgid "Music artist random fanart"
@@ -631,7 +631,7 @@ msgstr "Cerrar sesión"
 
 msgctxt "#32611"
 msgid "Stop now playing media"
-msgstr "Detener ahora la reproducción"
+msgstr "Detener ahora la reproducción multimedia"
 
 msgctxt "#32612"
 msgid "Log out after (minutes)"
@@ -639,7 +639,7 @@ msgstr "Cerrar sesión después de (minutos)"
 
 msgctxt "#32620"
 msgid "Enable RSS"
-msgstr "Activar RSS"
+msgstr "Habilitar RSS"
 
 msgctxt "#32621"
 msgid "RSS needs to be properly configured in Kodi and enabled!"
@@ -647,15 +647,15 @@ msgstr "¡RSS debe estar correctamente configurado en Kodi y activado!"
 
 msgctxt "#32630"
 msgid "Turn off screen via CEC"
-msgstr "Apagar pantalla a través de CEC"
+msgstr "Apagar la pantalla a través de CEC"
 
 msgctxt "#32631"
 msgid "Stop now playing media"
-msgstr "Detener ahora la reproducción"
+msgstr "Detener ahora la reproducción multimedia"
 
 msgctxt "#32632"
 msgid "Turn off screen via CEC after (minutes)"
-msgstr "Apagar pantalla a través de CEC después de (minutos)"
+msgstr "Apagar la pantalla a través de CEC después de (minutos)"
 
 #~ msgctxt "#32010"
 #~ msgid "Colors"

--- a/resources/language/resource.language.es_mx/strings.po
+++ b/resources/language/resource.language.es_mx/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.et_ee/strings.po
+++ b/resources/language/resource.language.et_ee/strings.po
@@ -5,17 +5,17 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: http://trac.kodi.tv/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2024-03-28 06:13+0000\n"
-"Last-Translator: rimasx <riks_12@hot.ee>\n"
+"PO-Revision-Date: 2022-03-10 15:00+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
 "Language-Team: Estonian <https://kodi.weblate.cloud/projects/kodi-add-ons-look-and-feel/screensaver-digitalclock/et_ee/>\n"
 "Language: et_ee\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.4\n"
+"X-Generator: Weblate 4.11.2\n"
 
 msgctxt "Addon Summary"
 msgid "Digital clock screensaver"
@@ -51,7 +51,7 @@ msgstr ""
 # empty strings from id 32011 to 32019
 msgctxt "#32020"
 msgid "Background"
-msgstr "Taust"
+msgstr ""
 
 # empty strings from id 32021 to 32024
 msgctxt "#32025"
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.fa_af/strings.po
+++ b/resources/language/resource.language.fa_af/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.fa_ir/strings.po
+++ b/resources/language/resource.language.fa_ir/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.fo_fo/strings.po
+++ b/resources/language/resource.language.fo_fo/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -219,7 +219,7 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Activer les informations météo"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -220,7 +220,7 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Activer les infos météo"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.hi_in/strings.po
+++ b/resources/language/resource.language.hi_in/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.id_id/strings.po
+++ b/resources/language/resource.language.id_id/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.is_is/strings.po
+++ b/resources/language/resource.language.is_is/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -220,7 +220,7 @@ msgid "Merge song artist and title"
 msgstr "Unisci artista e titolo della canzone"
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Abilita informazioni meteo"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -219,7 +219,7 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Įjungti orų informaciją"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.mi/strings.po
+++ b/resources/language/resource.language.mi/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.mk_mk/strings.po
+++ b/resources/language/resource.language.mk_mk/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.ms_my/strings.po
+++ b/resources/language/resource.language.ms_my/strings.po
@@ -219,7 +219,7 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Benarkan maklumat cuaca"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.mt_mt/strings.po
+++ b/resources/language/resource.language.mt_mt/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.my_mm/strings.po
+++ b/resources/language/resource.language.my_mm/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -220,7 +220,7 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Pokazuj informacje o pogodzie"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -230,10 +230,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Включить информацию о погоде"
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr "Значки погоды"

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.sl_si/strings.po
+++ b/resources/language/resource.language.sl_si/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.sq_al/strings.po
+++ b/resources/language/resource.language.sq_al/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.sr_rs/strings.po
+++ b/resources/language/resource.language.sr_rs/strings.po
@@ -220,7 +220,7 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Омогући податке о временској прогнози"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/resources/language/resource.language.sr_rs@latin/strings.po
@@ -220,7 +220,7 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Omogući podatke o vremenskoj prognozi"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.ta_in/strings.po
+++ b/resources/language/resource.language.ta_in/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.tg_tj/strings.po
+++ b/resources/language/resource.language.tg_tj/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.th_th/strings.po
+++ b/resources/language/resource.language.th_th/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -219,7 +219,7 @@ msgid "Merge song artist and title"
 msgstr ""
 
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "Hava durumu bilgisini etkinleştir"
 
 msgctxt "#32240"

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.uz_uz/strings.po
+++ b/resources/language/resource.language.uz_uz/strings.po
@@ -231,10 +231,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.vi_vn/strings.po
+++ b/resources/language/resource.language.vi_vn/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -232,10 +232,15 @@ msgstr "合并歌手和歌名"
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr "启用天气信息"
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr "天气图标"

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -232,10 +232,15 @@ msgstr ""
 
 # empty strings from id 32224 to 32229
 msgctxt "#32230"
-msgid "Enable weather information"
+msgid "Enable weather temperature information"
 msgstr ""
 
-# empty strings from id 32231 to 32239
+# empty strings from id 32231 to 32234
+msgctxt "#32235"
+msgid "Enable weather conditions information"
+msgstr ""
+
+# empty strings from id 32236 to 32239
 msgctxt "#32240"
 msgid "Weather icons"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -26,19 +26,20 @@
 		<setting label="32222" type="text" enable="false" subsetting="true" visible="eq(-1,true) + eq(-2,false) + eq(-3,true) + eq(-5,true)"/>
 		<setting id="albumartshow" label="32250" type="bool" subsetting="true" visible="eq(-6,true)" default="false"/>
 		<setting id="weatherinfoshow" label="32230" type="bool" visible="eq(-7,true)" default="false"/>
-		<setting id="weathericonformat" type="select" label="32240" subsetting="true" visible="eq(-8,true) + eq(-1,true)" default="1" lvalues="32241|32242|32243|32244|32245"/>
-		<setting id="cpuusage" label="32260" type="bool" visible="eq(-9,true)" default="false"/>
-		<setting id="batterylevel" label="32261" type="bool" visible="eq(-10,true)" default="false"/>
-		<setting id="freememory" label="32262" type="bool" visible="eq(-11,true)" default="false"/>
-		<setting id="cputemp" label="32266" type="bool" visible="eq(-12,true)" default="false"/>
-		<setting id="gputemp" label="32267" type="bool" visible="eq(-13,true)" default="false"/>
-		<setting id="hddtemp" label="32268" type="bool" visible="eq(-14,true)" default="false"/>
+		<setting id="weathercondshow" label="32235" type="bool" visible="eq(-8,true)" default="false"/>
+		<setting id="weathericonformat" type="select" label="32240" subsetting="true" visible="eq(-9,true) + eq(-1,true)" default="1" lvalues="32241|32242|32243|32244|32245"/>
+		<setting id="cpuusage" label="32260" type="bool" visible="eq(-10,true)" default="false"/>
+		<setting id="batterylevel" label="32261" type="bool" visible="eq(-11,true)" default="false"/>
+		<setting id="freememory" label="32262" type="bool" visible="eq(-12,true)" default="false"/>
+		<setting id="cputemp" label="32266" type="bool" visible="eq(-13,true)" default="false"/>
+		<setting id="gputemp" label="32267" type="bool" visible="eq(-14,true)" default="false"/>
+		<setting id="hddtemp" label="32268" type="bool" visible="eq(-15,true)" default="false"/>
 		<setting id="fps" label="32269" type="bool" visible="eq(-15,true)" default="false"/>
-		<setting id="cuptime" label="32270" type="bool" visible="eq(-16,true)" default="false"/>
-		<setting id="tuptime" label="32271" type="bool" visible="eq(-17,true)" default="false"/>
-		<setting id="movies" label="32263" type="bool" visible="eq(-18,true)" default="false"/>
-		<setting id="tvshows" label="32264" type="bool" visible="eq(-19,true)" default="false"/>
-		<setting id="music" label="32265" type="bool" visible="eq(-20,true)" default="false"/>
+		<setting id="cuptime" label="32270" type="bool" visible="eq(-17,true)" default="false"/>
+		<setting id="tuptime" label="32271" type="bool" visible="eq(-18,true)" default="false"/>
+		<setting id="movies" label="32263" type="bool" visible="eq(-19,true)" default="false"/>
+		<setting id="tvshows" label="32264" type="bool" visible="eq(-20,true)" default="false"/>
+		<setting id="music" label="32265" type="bool" visible="eq(-21,true)" default="false"/>
 	</category>
     <category id="colorandopacity" label="32010">
 		<setting label="32310" type="action" action="RunScript(script.skin.helper.colorpicker,skinstring=screensaver.digitalclock.hourcolor)"/>


### PR DESCRIPTION
  Until recently, I was using "Multi Weather" add-on with Kodi, and it was perfectly compatible with digitalclock screensaver. However, with Yahoo closing API access for new users, "Multi Weather" add-on became less useful out or the box, and was even marked as broken in Kodi's repo, so I had to switch to NOAA weather add-on. That, unfortunately, broke the screensaver, and the weather info was not shown anymore.

The issue appears to be caused by digitalclock plugin using "Weather.Location" property as an "umbrella validator" for data provided by weather add-on. This property is not provided by NOAA plugin, and it is not exposed by digitalclock plugin anyway, so with this PR I suggest to switch to explicitly validating the data that is going to be displayed, i.e. Weather.Temperature and Weather.Conditions .

Implementation notes:

- Unfortunately, "weatherinfoshow" cannot be renamed to something like "weathertempshow", because this will be a breaking change that will disable this setting for existing users and will require them to turn in back on explicitly.
- Error messages deliberately uses technical style so that a non-technical user better understands that the it is a fault of a weather plugin's internals, and not something on weather provider's side or something that a user can configure inside kodi
- I took this chance to make temperature and weather condition reports be toggled separately. Not only it enables a user to keep getting the temperature from a hypothetical provider that does not support displaying weather conditions, but it also makes it possible to disable annoying false weather condition reports that are shown instead of temperature (here's my real-life use-case: I live about 20 miles away and 300 feet higher that the airport that reports the weather. I look into the window to know that it's sunny, and I look on my Kodi display to know the temperature, but with 50% probability the temperature will be replaced with long "Mostly Cloudy" message because the airport reports it and the textarea is limited).

